### PR TITLE
SetTickFreq( int, int ) is deprecated as of wx 2.9.2

### DIFF
--- a/src/settings++/tab_audio.cpp
+++ b/src/settings++/tab_audio.cpp
@@ -37,11 +37,11 @@ void audio_panel::initAudioSizer(wxStaticBoxSizer* sizer) {
     for (int i = 0; i < ctrl_audio_sliders_size; ++i ) {
         ctrl_audio_sliders[i] = new wxSlider(this, AO_SLI[i].id, 1, 0, i == 0 ? 128 : 100, WX_DEF_P, WX_SLI_S, SLI_STYLE, WX_DEF_V);
         ctrl_audio_sliders[i]->SetToolTip(AO_SLI[i].tTip[0]);
-        ctrl_audio_sliders[i]->SetTickFreq( 10, 1 );
+        ctrl_audio_sliders[i]->SetTickFreq( 10 );
         sizer->Add( new wxStaticText(this, -1, (AO_SLI[i].lbl)), 0, wxTOP, 15 );
         sizer->Add( ctrl_audio_sliders[i], 0, wxALIGN_LEFT, 0 );
     }
-    ctrl_audio_sliders[0]->SetTickFreq((128 / 10 )  ,1);
+    ctrl_audio_sliders[0]->SetTickFreq( (128 / 10) );
 }
 
 audio_panel::audio_panel(wxWindow *parent, wxWindowID id , const wxString &title , const wxPoint& pos , const wxSize& size, long style)


### PR DESCRIPTION
second parameter never used on archs but win, and anyway cannot be other than the arch-specific value
