### PR TITLE
fixed WRITABLE definition (Mac)

### DIFF
--- a/src/infodialog.cpp
+++ b/src/infodialog.cpp
@@ -33,10 +33,10 @@
 #include "updater/updatehelper.h"
 #include <wx/textctrl.h>
 #include <wx/app.h>
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 # include <unistd.h>
 # define WRITABLE W_OK
-#elif __WIN32__ || _MSC_VER
+#elif defined(__WIN32__) || defined(_MSC_VER)
 # include <io.h>
 # define WRITABLE 02
 #else


### PR DESCRIPTION
cleaned #ifdef for WRITABLE, and included MacOS test (not recognized as **unix** but as **APPLE**)
