### PR TITLE
lock boost filesystem to v2

### DIFF
--- a/src/torrentwrapper.h
+++ b/src/torrentwrapper.h
@@ -3,6 +3,7 @@
 
 #ifndef NO_TORRENT_SYSTEM
 
+#define BOOST_FILESYSTEM_VERSION 2
 
 #include <wx/arrstr.h>
 #include <wx/event.h>


### PR DESCRIPTION
FYI, boost filesystem is now at v3, and is deprecating v2. When (and if) v4 comes out, v2 will be REMOVED, so torrent code won't work anymore
