### PR TITLE
fix #70: battle infos reopens after window is resized

### DIFF
--- a/src/battlelist/battlelisttab.cpp
+++ b/src/battlelist/battlelisttab.cpp
@@ -168,6 +168,7 @@ BattleListTab::BattleListTab( wxWindow* parent )
 	Layout();
 
 	SelectBattle( 0 );
+	ShowExtendedInfos(true);
 	ConnectGlobalEvent(this, GlobalEvent::OnUnitsyncReloaded, wxObjectEventFunction(&BattleListTab::OnUnitsyncReloaded));
 }
 
@@ -507,7 +508,5 @@ void BattleListTab::OnResize( wxSizeEvent& event )
 {
 	SetSize( event.GetSize() );
 	Layout();
-	// window too small, hide additional infos
-	ShowExtendedInfos( ( GetClientSize().GetHeight() > 400 ) );
 }
 


### PR DESCRIPTION
- OnResize: do not toggle battle infos
- Open battle infos on start as it is expected
