### PR TITLE
 Fixed .desktop file conformity

### DIFF
--- a/src/springlobby.desktop
+++ b/src/springlobby.desktop
@@ -2,7 +2,7 @@
 Name=SpringLobby
 Comment=Play real-time strategy games using the Spring engine
 Exec=springlobby
-Icon=springlobby.svg
+Icon=springlobby
 Terminal=false
 Type=Application
 Categories=Application;Game;StrategyGame;


### PR DESCRIPTION
We currently

``` bash
# Fix desktopfile
sed -i "s/Icon\=springlobby.svg/Icon\=springlobby/" %{buildroot}%{_datadir}/applications/%{name}.desktop
```

at @openSUSE games so it might be time to finally push this upstream. I am not sure if the `X-SUSE...` stuff is really necessary.
