### PR TITLE
Update springlobby.desktop

### DIFF
--- a/src/springlobby.desktop
+++ b/src/springlobby.desktop
@@ -5,4 +5,4 @@ Exec=springlobby
 Icon=springlobby
 Terminal=false
 Type=Application
-Categories=Application;Game;StrategyGame;
+Categories=Game;StrategyGame;


### PR DESCRIPTION
- `X-SuSE-translate=false` should not be set by upstream
- `Categories=Application` might be a Fedoraism (it breaks the build on build.opensuse.org)
