### PR TITLE
feature request from issue #241: AppData descriptor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,16 @@ Tobi
 
   map selector, threaded unitsync
 
+abma
+
+  Current maintainer
+
+MajBoredom
+
+  Code contributor, bug fixes
+
+
+
 Retired Team Members
 
 tronic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ ELSE (WIN32)
 	    ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)
     install(FILES src/springlobby.desktop DESTINATION
 	    ${CMAKE_INSTALL_PREFIX}/share/applications)
+    install(FILES share/freedesktop.org/springlobby.appdata.xml DESTINATION /usr/share/appdata)
 ENDIF (WIN32)
 
 add_custom_target(pack

--- a/share/freedesktop.org/README
+++ b/share/freedesktop.org/README
@@ -1,0 +1,17 @@
+This directory contains files that are needed for FreeDesktop.org to feature springlobby in so-called software centers
+  for desktop software such as gnome, kde, or xfce.
+
+springlobby.appdata.xml is the descriptor file. It contains references to screenshot images found on the web (springlobby.info),
+  so these screenshots need to remain at this location or their locations need to be updated in this file if they change.
+
+Alternatively, one can write a "springlobby.appdata.xml.in" that would be processed by intltool or some internationalization 
+  program that would produce a locale-specific descriptor, but for now we have a default version in English.
+
+I've included the springlobby.appdata.xml file to get us started, and configured CMake so that "make install" 
+  copies it to /usr/share/appdata, where it is supposed to go.
+
+We should perhaps look at incorporating intltool or itstool for internationalization. We have plenty of people in the community
+  that can write a springlobby description in different languages!
+
+  -MajBoredom
+

--- a/share/freedesktop.org/springlobby.appdata.xml
+++ b/share/freedesktop.org/springlobby.appdata.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+ <id type="desktop">springlobby.desktop</id>
+ <metadata_license>GFDL-1.3</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Springlobby</name>
+ <summary>Play online RTS games with the Spring engine</summary>
+ <description>
+  <p>
+    Springlobby is a windowed client that allows you to download and play a wide variety of games using the Spring engine,
+      a popular RTS game engine.
+    Using this program, you can connect to one of dozens of free 24x7 battleroom servers on the internet that are accessible 
+      from our master server.
+    You'll need to download the spring RTS engine and supply lobby with its installation path.
+    After that, springlobbylobby will let you create an account and you're set to go!
+  </p>
+  <p>Popular games that use the spring engine are:
+  <ul>
+   <li>Balanced Annihilation</li>
+   <li>Tech Annihilation</li>
+   <li>Zero-K</li>
+   <li>Evolution RTS</li>
+   <li>Spring:1944</li>
+   <li>NOTA</li>
+   <li>XTA</li>
+   <li>Lots more developed regularly!</li>
+  </ul>
+  </p>
+  <p>The springlobby home page can be found at http://www.springlobby.info/ or you can visit our project page
+       on github at http://www.github.com/springlobby/springlobby/</p>
+  <p>You can find out more about the spring engine and its games at http://www.springrts.com/.</p>
+ </description>
+ <screenshots>
+  <screenshot type="default" width="892" height="755">http://springlobby.info/landing/screenshots/11_chat.png</screenshot>
+  <screenshot type="default" width="901" height="611">http://springlobby.info/landing/screenshots/01_welcome.png</screenshot>
+  <screenshot type="default" width="901" height="611">http://springlobby.info/landing/screenshots/31_tabs.png</screenshot>
+  <screenshot type="default" width="901" height="611">http://springlobby.info/landing/screenshots/30_tabs2.png</screenshot>
+  <screenshot type="default" width="901" height="611">http://springlobby.info/landing/screenshots/10_sp.png</screenshot>
+  <screenshot type="default" width="740" height="465">http://springlobby.info/landing/screenshots/97_groups.png</screenshot>
+  <screenshot type="default" width="740" height="465">http://springlobby.info/landing/screenshots/98_chat_prefs.png</screenshot>
+  <screenshot type="default" width="740" height="465">http://springlobby.info/landing/screenshots/99_spring_prefs.png</screenshot>
+ </screenshots>
+ <url type="homepage">http://springlobby.info/</url>
+ <url type="github">https://github.com/springlobby/springlobby</url>
+ <updatecontact></updatecontact>
+ <project_group>GNOME</project_group>
+</application>


### PR DESCRIPTION
Created this AppData descriptor as per the instructions on http://people.freedesktop.org/~hughsient/appdata/. I put it in ./share/freedesktop.org under the project root; I wasn't sure where else to put it. I added a README file to explain.

I also modified CMakeLists.txt so that it is installed at /usr/share/appdata during "make install". I tested the install and it works, but my desktop is XFCE and so doesn't use these files. I tested the XML and it was valid. Feel free to modify the file, I just wanted to get it started.

I also added our nicknames to the AUTHORS file.
