### PR TITLE
The new version of wxWidgets(3.1.0) does not trigger the HAVE_WX29 define

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -4,7 +4,7 @@
 #define SPRINGLOBBY_HEADERGUARD_DEFINES_H
 
 #if ( !defined(HAVE_WX29) && !defined(HAVE_WX28) )
-	#if( wxMAJOR_VERSION==2 && wxMINOR_VERSION == 9 ) || (wxMAJOR_VERSION == 3 && wxMINOR_VERSION == 0)
+	#if( wxMAJOR_VERSION==2 && wxMINOR_VERSION == 9 ) || (wxMAJOR_VERSION == 3)
 		#define HAVE_WX29
 	#elif( wxMAJOR_VERSION==2 && wxMINOR_VERSION == 8 )
 		#define HAVE_WX28


### PR DESCRIPTION
This change would allow compilation with all versions of wxWidgets 3, which I don't see reverting back to ascii as time continues.
