### PR TITLE
OSX: Allow (*.app;*.dylib) as source of unitsync

### DIFF
--- a/src/gui/options/springoptionstab.cpp
+++ b/src/gui/options/springoptionstab.cpp
@@ -248,13 +248,22 @@ void SpringOptionsTab::OnAddBundle(wxCommandEvent& /*event*/)
 	wxFileDialog pick( this, _( "Choose UnitSync library" ),
 				wxPathOnly(TowxString(SlPaths::GetUnitSync())),
 				wxFileName::FileName(TowxString(SlPaths::GetUnitSync())).GetFullName(),
+#ifdef __APPLE__
+				"Spring application or unitsync (*.app;*.dylib)|*.app;*.dylib");
+#else
 				GetUnitsyncFilter());
+#endif
 	if ( pick.ShowModal() == wxID_OK ) {
 		//get unitsync version & add to list
 		bool failed = false;
 		wxString failMessage;
 		LSL::SpringBundle bundle;
+#ifdef __APPLE__
+		wxString path = pick.GetPath();
+		bundle.unitsync = STD_STRING(path + (path.Contains("libunitsync.dylib") ? "" : "/Contents/MacOS/libunitsync.dylib"));
+#else
 		bundle.unitsync = STD_STRING(pick.GetPath());
+#endif
 		wxString version;
 		try {
 			bundle.AutoComplete();

--- a/src/gui/options/springoptionstab.cpp
+++ b/src/gui/options/springoptionstab.cpp
@@ -249,7 +249,7 @@ void SpringOptionsTab::OnAddBundle(wxCommandEvent& /*event*/)
 				wxPathOnly(TowxString(SlPaths::GetUnitSync())),
 				wxFileName::FileName(TowxString(SlPaths::GetUnitSync())).GetFullName(),
 #ifdef __APPLE__
-				"Spring application or unitsync (*.app;*.dylib)|*.app;*.dylib");
+				_T("Spring application or unitsync (*.app;*.dylib)|*.app;*.dylib"));
 #else
 				GetUnitsyncFilter());
 #endif
@@ -260,7 +260,7 @@ void SpringOptionsTab::OnAddBundle(wxCommandEvent& /*event*/)
 		LSL::SpringBundle bundle;
 #ifdef __APPLE__
 		wxString path = pick.GetPath();
-		bundle.unitsync = STD_STRING(path + (path.Contains("libunitsync.dylib") ? "" : "/Contents/MacOS/libunitsync.dylib"));
+		bundle.unitsync = STD_STRING(path + (path.EndsWith("libunitsync.dylib") ? "" : "/Contents/MacOS/libunitsync.dylib"));
 #else
 		bundle.unitsync = STD_STRING(pick.GetPath());
 #endif


### PR DESCRIPTION
This quickfix allows to select libunitsync.dylib or Spring.app when adding new engine.
OSX's browsing system treats Spring.app as a file (bundle) and doesn't allow to look inside.

Drawbacks of the hack: hardcoded strings; prompts second time for spring executable when wrong *.app selected; wrong error messages for *.app