### PR TITLE
batch#3

### DIFF
--- a/src/gui/hosting/hostbattledialog.cpp
+++ b/src/gui/hosting/hostbattledialog.cpp
@@ -98,22 +98,20 @@ HostBattleDialog::HostBattleDialog(wxWindow* parent)
 	m_mod_lbl->Wrap(-1);
 	topsizer->Add(m_mod_lbl, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
-	wxArrayString m_engine_picChoices;
 	wxBoxSizer* mod_choice_button_sizer2 = new wxBoxSizer(wxHORIZONTAL);
-	m_engine_pic = new wxChoice(m_panel, CHOOSE_ENGINE, wxDefaultPosition, wxDefaultSize, m_engine_picChoices, 0);
-	m_engine_pic->SetToolTip(_("Select the engine version to play."));
-	mod_choice_button_sizer2->Add(m_engine_pic, 0, wxALL, 5);
+	m_engine_choice = new wxChoice(m_panel, CHOOSE_ENGINE);
+	m_engine_choice->SetToolTip(_("Select the engine version to play."));
+	mod_choice_button_sizer2->Add(m_engine_choice, 0, wxALL, 5);
 	topsizer->Add(mod_choice_button_sizer2, 0, wxEXPAND | wxALL, 1);
 
 	m_mod_lbl = new wxStaticText(m_panel, wxID_ANY, _("Game"), wxDefaultPosition, wxDefaultSize, 0);
 	m_mod_lbl->Wrap(-1);
 	topsizer->Add(m_mod_lbl, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
-	wxArrayString m_mod_picChoices;
 	wxBoxSizer* mod_choice_button_sizer = new wxBoxSizer(wxHORIZONTAL);
-	m_mod_pic = new wxChoice(m_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_mod_picChoices, 0);
-	m_mod_pic->SetToolTip(_("Select the game to play."));
-	mod_choice_button_sizer->Add(m_mod_pic, 0, wxALL, 5);
+	m_game_choice = new wxChoice(m_panel, wxID_ANY);
+	m_game_choice->SetToolTip(_("Select the game to play."));
+	mod_choice_button_sizer->Add(m_game_choice, 0, wxALL, 5);
 
 	wxBitmap mp = charArr2wxBitmap(arrow_refresh_png, sizeof(arrow_refresh_png));
 	m_refresh_btn = new wxBitmapButton(m_panel, BTN_REFRESH, mp);
@@ -293,39 +291,39 @@ HostBattleDialog::HostBattleDialog(wxWindow* parent)
 
 void HostBattleDialog::ReloadModList()
 {
-	m_mod_pic->Clear();
+	m_game_choice->Clear();
 
 	wxArrayString modlist = lslTowxArrayString(LSL::usync().GetGameList());
 	wxString last = sett().GetLastHostMod();
 
 	size_t nummods = modlist.Count();
 	for (size_t i = 0; i < nummods; i++) {
-		m_mod_pic->Insert(modlist[i], i);
+		m_game_choice->Insert(modlist[i], i);
 		if (last == modlist[i])
-			m_mod_pic->SetSelection(i);
+			m_game_choice->SetSelection(i);
 	}
 
-	if (m_mod_pic->GetSelection() == wxNOT_FOUND) {
-		m_mod_pic->SetSelection(0);
+	if (m_game_choice->GetSelection() == wxNOT_FOUND) {
+		m_game_choice->SetSelection(0);
 	}
 }
 
 void HostBattleDialog::ReloadEngineList()
 {
-	m_engine_pic->Clear();
+	m_engine_choice->Clear();
 	std::map<std::string, LSL::SpringBundle> versions = SlPaths::GetSpringVersionList();
 	const std::string last = SlPaths::GetCurrentUsedSpringIndex();
 	int i = 0;
 	for (auto pair : versions) {
-		m_engine_pic->Insert(TowxString(pair.first), i);
+		m_engine_choice->Insert(TowxString(pair.first), i);
 		if (last == pair.first) {
-			m_engine_pic->SetSelection(i);
+			m_engine_choice->SetSelection(i);
 		}
 		i++;
 	}
 
-	if (m_engine_pic->GetSelection() == wxNOT_FOUND) {
-		m_engine_pic->SetSelection(0);
+	if (m_engine_choice->GetSelection() == wxNOT_FOUND) {
+		m_engine_choice->SetSelection(0);
 	}
 	//unitsync change needs a refresh of games as well
 	ReloadModList();
@@ -334,13 +332,13 @@ void HostBattleDialog::ReloadEngineList()
 
 void HostBattleDialog::OnOk(wxCommandEvent& /*unused*/)
 {
-	if (m_mod_pic->GetSelection() == wxNOT_FOUND) {
+	if (m_game_choice->GetSelection() == wxNOT_FOUND) {
 		wxLogWarning(_T( "no game selected" ));
 		customMessageBox(SL_MAIN_ICON, _("You have to select a game first."), _("No game selected."), wxOK);
 		return;
 	}
 
-	if (m_engine_pic->GetSelection() == wxNOT_FOUND) {
+	if (m_engine_choice->GetSelection() == wxNOT_FOUND) {
 		wxLogWarning(_T( "no engine selected" ));
 		customMessageBox(SL_MAIN_ICON, _("You have to select a engine version first."), _("No engine selected."), wxOK);
 		return;
@@ -349,7 +347,7 @@ void HostBattleDialog::OnOk(wxCommandEvent& /*unused*/)
 	if (m_desc_text->GetValue().IsEmpty())
 		m_desc_text->SetValue(_T( "(none)" ));
 	sett().SetLastHostDescription(m_desc_text->GetValue());
-	sett().SetLastHostMod(m_mod_pic->GetString(m_mod_pic->GetSelection()));
+	sett().SetLastHostMod(m_game_choice->GetString(m_game_choice->GetSelection()));
 	wxString password = m_pwd_text->GetValue();
 	password.Replace(_T(" "), wxEmptyString);
 	sett().SetLastHostPassword(password);
@@ -439,7 +437,7 @@ void HostBattleDialog::OnUseRelay(wxCommandEvent&)
 
 void HostBattleDialog::OnEngineSelect(wxCommandEvent& /*event*/)
 {
-	SlPaths::SetUsedSpringIndex(STD_STRING(m_engine_pic->GetString(m_engine_pic->GetSelection())));
+	SlPaths::SetUsedSpringIndex(STD_STRING(m_engine_choice->GetString(m_engine_choice->GetSelection())));
 	LSL::usync().ReloadUnitSyncLib();
 	ReloadEngineList();
 }

--- a/src/gui/hosting/hostbattledialog.h
+++ b/src/gui/hosting/hostbattledialog.h
@@ -46,8 +46,8 @@ private:
 	wxStaticText* m_desc_lbl;
 	wxTextCtrl* m_desc_text;
 	wxStaticText* m_mod_lbl;
-	wxChoice* m_mod_pic;
-	wxChoice* m_engine_pic;
+	wxChoice* m_engine_choice;
+	wxChoice* m_game_choice;
 	wxStaticText* m_pwd_lbl;
 	wxTextCtrl* m_pwd_text;
 	wxChoice* m_rank_direction;

--- a/src/gui/singleplayertab.cpp
+++ b/src/gui/singleplayertab.cpp
@@ -128,15 +128,15 @@ SinglePlayerTab::SinglePlayerTab(wxWindow* parent, MainSinglePlayerTab& msptab)
 	m_mod_lbl = new wxStaticText(this, -1, _("Game:"));
 	m_ctrl_sizer->Add(m_mod_lbl, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-	m_mod_pick = new wxChoice(this, SP_MOD_PICK);
-	m_ctrl_sizer->Add(m_mod_pick, 1, wxALL, 5);
+	m_game_choice = new wxChoice(this, SP_MOD_PICK);
+	m_ctrl_sizer->Add(m_game_choice, 1, wxALL, 5);
 
 	m_mod_lbl = new wxStaticText(this, -1, _("Engine:"));
 	m_ctrl_sizer->Add(m_mod_lbl, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-	m_engine_pick = new wxChoice(this, SP_ENGINE_PICK);
-	m_engine_pick->SetToolTip(_("Select the engine version to play."));
-	m_ctrl_sizer->Add(m_engine_pick, 1, wxALL, 5);
+	m_engine_choice = new wxChoice(this, SP_ENGINE_PICK);
+	m_engine_choice->SetToolTip(_("Select the engine version to play."));
+	m_ctrl_sizer->Add(m_engine_choice, 1, wxALL, 5);
 
 	//  m_ctrl_sizer->Add( 0, 0, 1, wxEXPAND, 0 );
 
@@ -203,7 +203,7 @@ void SinglePlayerTab::ReloadMaplist()
 	} else {
 		m_map_pick->SetStringSelection(TowxString(m_battle.GetHostMapName()));
 		if (m_map_pick->GetStringSelection().IsEmpty()) {
-			SetMap(m_mod_pick->GetCount() - 1);
+			SetMap(m_game_choice->GetCount() - 1);
 		}
 	}
 }
@@ -211,15 +211,15 @@ void SinglePlayerTab::ReloadMaplist()
 
 void SinglePlayerTab::ReloadModlist()
 {
-	m_mod_pick->Clear();
-	m_mod_pick->Append(lslTowxArrayString(LSL::usync().GetGameList()));
-	m_mod_pick->Insert(_("-- Select one --"), m_mod_pick->GetCount());
+	m_game_choice->Clear();
+	m_game_choice->Append(lslTowxArrayString(LSL::usync().GetGameList()));
+	m_game_choice->Insert(_("-- Select one --"), m_game_choice->GetCount());
 	if (m_battle.GetHostGameName().empty()) {
-		m_mod_pick->SetSelection(m_mod_pick->GetCount() - 1);
+		m_game_choice->SetSelection(m_game_choice->GetCount() - 1);
 	} else {
-		m_mod_pick->SetStringSelection(TowxString(m_battle.GetHostGameName()));
-		if (m_mod_pick->GetStringSelection().empty()) {
-			SetMod(m_mod_pick->GetCount() - 1);
+		m_game_choice->SetStringSelection(TowxString(m_battle.GetHostGameName()));
+		if (m_game_choice->GetStringSelection().empty()) {
+			SetMod(m_game_choice->GetCount() - 1);
 		}
 	}
 }
@@ -229,22 +229,22 @@ void SinglePlayerTab::ReloadEngineList()
 {
 	SlPaths::ValidatePaths();
 
-	m_engine_pick->Clear();
+	m_engine_choice->Clear();
 
 	std::map<std::string, LSL::SpringBundle> versions = SlPaths::GetSpringVersionList();
 	const std::string last = SlPaths::GetCurrentUsedSpringIndex();
 	int i = 0;
 
 	for (auto pair : versions) {
-		m_engine_pick->Insert(TowxString(pair.first), i);
+		m_engine_choice->Insert(TowxString(pair.first), i);
 		if (last == pair.first) {
-			m_engine_pick->SetSelection(i);
+			m_engine_choice->SetSelection(i);
 		}
 		i++;
 	}
 
-	if (m_engine_pick->GetSelection() == wxNOT_FOUND) {
-		m_engine_pick->SetSelection(0);
+	if (m_engine_choice->GetSelection() == wxNOT_FOUND) {
+		m_engine_choice->SetSelection(0);
 	}
 
 	if (i == 0) {
@@ -299,7 +299,7 @@ void SinglePlayerTab::ResetUsername()
 void SinglePlayerTab::SetMod(unsigned int index)
 {
 	//ui().ReloadUnitSync();
-	if (index >= m_mod_pick->GetCount() - 1) {
+	if (index >= m_game_choice->GetCount() - 1) {
 		m_battle.SetHostGame("", "");
 	} else {
 		try {
@@ -312,13 +312,13 @@ void SinglePlayerTab::SetMod(unsigned int index)
 	m_minimap->UpdateMinimap();
 	m_battle.SendHostInfo(IBattle::HI_Restrictions); // Update restrictions in options.
 	m_battle.SendHostInfo(IBattle::HI_Game_Changed); // reload mod options
-	m_mod_pick->SetSelection(index);
+	m_game_choice->SetSelection(index);
 }
 
 
 bool SinglePlayerTab::ValidSetup() const
 {
-	if (m_mod_pick->GetSelection() == wxNOT_FOUND) {
+	if (m_game_choice->GetSelection() == wxNOT_FOUND) {
 		wxLogWarning(_T("no game selected"));
 		customMessageBox(SL_MAIN_ICON, _("You have to select a game first."), _("Game setup error"));
 		return false;
@@ -352,7 +352,7 @@ void SinglePlayerTab::OnMapSelect(wxCommandEvent& /*unused*/)
 
 void SinglePlayerTab::OnModSelect(wxCommandEvent& /*unused*/)
 {
-	const int index = m_mod_pick->GetCurrentSelection();
+	const int index = m_game_choice->GetCurrentSelection();
 
 	if (index == wxNOT_FOUND) { return; }
 
@@ -364,13 +364,13 @@ void SinglePlayerTab::OnModSelect(wxCommandEvent& /*unused*/)
 
 void SinglePlayerTab::OnEngineSelect(wxCommandEvent& /*event*/)
 {
-	const int index = m_engine_pick->GetSelection();
+	const int index = m_engine_choice->GetSelection();
 
 	if (index == wxNOT_FOUND) {
-		wxLogError("Invalid index selected: %d > %d", index, m_engine_pick->GetCount());
+		wxLogError("Invalid index selected: %d > %d", index, m_engine_choice->GetCount());
 		return;
 	}
-	const std::string selection = STD_STRING(m_engine_pick->GetString(index));
+	const std::string selection = STD_STRING(m_engine_choice->GetString(index));
 	wxLogMessage("Selected engine version %s", selection.c_str());
 
 	SlPaths::SetUsedSpringIndex(selection);

--- a/src/gui/singleplayertab.h
+++ b/src/gui/singleplayertab.h
@@ -66,8 +66,8 @@ private:
 	MapCtrl* m_minimap;
 	wxWindow* m_nominimap;
 	wxChoice* m_map_pick;
-	wxChoice* m_mod_pick;
-	wxChoice* m_engine_pick;
+	wxChoice* m_engine_choice;
+	wxChoice* m_game_choice;
 	wxStaticText* m_map_lbl;
 	wxStaticText* m_mod_lbl;
 	wxButton* m_select_btn;

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -15,7 +15,7 @@ Statusbar::Statusbar(wxWindow* parent)
 {
 	int w[3] = {460, -1, 120};
 	SetFieldsCount(3, w);
-	PushStatusText(TowxString(getSpringlobbyVersion()), 1);
+	PushStatusText(TowxString(getSpringlobbyAgent()), 1);
 	taskBar = new TaskBar(this);
 }
 

--- a/src/gui/ui.cpp
+++ b/src/gui/ui.cpp
@@ -274,11 +274,10 @@ ChatPanel* Ui::GetChannelChatPanel(const wxString& channel)
 ////////////////////////////////////////////////////////////////////////////////////////////
 // EVENTS
 ////////////////////////////////////////////////////////////////////////////////////////////
-
 //! @brief Called when connected to a server
 //!
 //! @todo Display in servertab
-void Ui::OnConnected(IServer& server, const wxString& server_name, const wxString& version, bool /*supported*/)
+void Ui::OnConnected(IServer& server, const wxString& server_name, const wxString& /*version*/, bool /*supported*/)
 {
 	slLogDebugFunc("");
 
@@ -291,14 +290,6 @@ void Ui::OnConnected(IServer& server, const wxString& server_name, const wxStrin
 	mw().GetBattleListTab().OnConnected();
 
 	ReopenServerTab();
-
-	if (version.empty()) {
-		wxLogWarning("default version supplied from server is empty!");
-		return;
-	}
-	std::map<std::string, LSL::SpringBundle> enginebundles = SlPaths::GetSpringVersionList();
-	if (!SlPaths::GetCompatibleVersion(STD_STRING(version)).empty())
-		return;
 }
 
 void Ui::OnLoggedIn()

--- a/src/gui/ui.cpp
+++ b/src/gui/ui.cpp
@@ -48,7 +48,6 @@
 #include "gui/agreementdialog.h"
 #include "updatehelper.h"
 #include "gui/customdialogs.h"
-#include "httpfile.h"
 #include "gui/textentrydialog.h"
 #include "log.h"
 #include "settings.h"
@@ -62,7 +61,6 @@
 
 
 SLCONFIG("/General/AutoUpdate", true, "Determines if springlobby should check for updates on startup");
-SLCONFIG("/General/LastUpdateCheck", 0L, "Last time springlobby checked for an update");
 SLCONFIG("/GUI/StartTab", (long)MainWindow::PAGE_BATTLELIST, "which tab to show on startup");
 SLCONFIG("/Chat/BroadcastEverywhere", true, "setting to spam the server messages in all channels");
 SLCONFIG("/Server/Autoconnect", false, "Connect to server on startup");
@@ -738,12 +736,7 @@ void Ui::OnInit()
 		mw().ShowTab(cfg().ReadLong(_T( "/GUI/StartTab" )));
 		//don't ask for updates on first run, that's a bit much for a newbie
 		if (cfg().ReadBool(_T("/General/AutoUpdate"))) {
-			const time_t now = time(0);
-			const size_t lastcheck = cfg().ReadLong(_T("/General/LastUpdateCheck"));
-			if (now - lastcheck > 3600) {
-				CheckForUpdates(false);
-				cfg().Write(_T("/General/LastUpdateCheck"), (long)now);
-			}
+			CheckForUpdates(false);
 		}
 	}
 }
@@ -785,14 +778,17 @@ void Ui::OnLobbyDownloaded(wxCommandEvent& data)
 	mw().Close();
 }
 
-void Ui::CheckForUpdates(bool show)
+void Ui::CheckForUpdates(bool is_interactive)
 {
-	std::string latestversion = GetHttpFile(GetLatestVersionUrl());
-	latestversion = STD_STRING(TowxString(latestversion).Trim().Trim(false));
+	std::string latestversion = GetLatestVersion(is_interactive);
 
 	if (latestversion.empty()) {
-		if (show) {
-			customMessageBoxModal(SL_MAIN_ICON, _("There was an error checking for the latest version.\nPlease try again later.\nIf the problem persists, please use Help->Report Bug to report this bug."), _("Error"));
+		if (is_interactive) {
+			customMessageBoxModal(SL_MAIN_ICON, _(
+			  "There was an error checking for the latest version.\n"
+			  "Please try again later.\n"
+			  "If the problem persists, please use Help->Report Bug to report this bug."),
+			  _("Error"));
 		}
 		return;
 	}
@@ -801,7 +797,7 @@ void Ui::CheckForUpdates(bool show)
 
 	const wxString msg = _("Your Version: ") + myVersion + _T("\n") + _("Latest Version: ") + latestversion;
 	if (latestversion == myVersion) {
-		if (show) {
+		if (is_interactive) {
 			customMessageBoxModal(SL_MAIN_ICON, _("Your SpringLobby version is up to date.\n\n") + msg, _("Up to Date"));
 		}
 		return;

--- a/src/gui/ui.h
+++ b/src/gui/ui.h
@@ -116,7 +116,7 @@ public:
 
 	//! the welcome box, should be called in all code paths directly after MainWindow might be shown for the first time
 	void FirstRunWelcome();
-	void CheckForUpdates(bool show);
+	void CheckForUpdates(bool is_interactive);
 	void EnableDebug(bool enable);
 	void OnInvalidFingerprintReceived(const std::string& fingerprint, const std::string& expected_fingerprint);
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,7 +1,8 @@
 /* This file is part of the Springlobby (GPL v2 or later), see COPYING */
 
+#include <mutex>
+#include <sys/time.h>
 #include <wx/log.h>
-#include <boost/thread/mutex.hpp>
 
 #include "log.h"
 #include "utils/conversion.h"
@@ -57,7 +58,7 @@ public:
 	// catch and process all log messages
 	void DoLogRecord(wxLogLevel loglevel, const wxString& msg, const wxLogRecordInfo& info) override
 	{
-		boost::mutex::scoped_lock lock(m_mutex);
+		std::lock_guard<std::mutex> lock(m_mutex);
 
 		if (gui && (loglevel == wxLOG_Error || loglevel == wxLOG_FatalError)) // show user only errors
 		{
@@ -112,7 +113,7 @@ private:
 	bool m_console;
 	//	bool m_gui;
 	FILE* m_logfile;
-	boost::mutex m_mutex;
+	std::mutex m_mutex;
 };
 
 

--- a/src/updatehelper.h
+++ b/src/updatehelper.h
@@ -7,5 +7,9 @@
 
 std::string GetDownloadUrl(const std::string& version);
 std::string GetLatestVersionUrl();
+// returns current version; if use_cached and check timer has not expired
+//         empty string   ; if download failed
+//         latest version ; otherwise
+std::string GetLatestVersion(bool use_cached = true);
 
 #endif


### PR DESCRIPTION
On a side note: something needs to be done regarding relay host's inability to deal with many engine versions, let alone many different engines. I've tried opening an issue about it at https://github.com/springlobby/relayhost but they are disabled on that repository (by default on forks?).

Anyway, the active version leftovers in the first commit below could be used within hostbattledialog.cpp to signal which are compatible, but:
1. This is ugly as hell
2. People are going to be confused about only one engine being supported (which they probably already are and there is just no clue given to them about this fact).
3. I disagree with how the relay host is implemented (it should be a dumb relay that just forwards packets around, KISS) and this issue can be 100% blamed on its implementation.