### PR TITLE
updated battle list sort chains and color highlights

### DIFF
--- a/src/gui/basedataviewmodel.h
+++ b/src/gui/basedataviewmodel.h
@@ -7,6 +7,8 @@
 #include <climits>
 #include <set>
 #include "log.h"
+#include "../utils/conversion.h"
+
 #define DEFAULT_COLUMN UINT_MAX
 
 

--- a/src/gui/battlelist/battledataviewmodel.cpp
+++ b/src/gui/battlelist/battledataviewmodel.cpp
@@ -249,7 +249,7 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
 			int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
 			sortingResult = playersA - playersB;
-			
+
 			if (USE_SMART_SORTING) {			
 				if (0 == sortingResult) {
 					int playersA = battleA->GetNumPlayers() ;
@@ -298,7 +298,7 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 	if (battle->GetNumPlayers() - battle->GetSpectators() == 0) {
 		attr.SetColour(INACTIVE_ROOM_COLOUR);
 	}
-	
+
 	//If founder is cause of highlight
 	wxString groupName = useractions().GetGroupOfUser(battle->GetFounder().GetNick());
 	if (groupName != wxEmptyString) {
@@ -316,7 +316,7 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 			}
 		}
 	}
-	
+
 	if (SHOW_GAME_COLORS) {
 		// if no highlight was set, use a game-dependent shade of grey as background (windows only)
 		attr.SetBackgroundColour(battle->GetHostGameBackgroundColour());

--- a/src/gui/battlelist/battledataviewmodel.cpp
+++ b/src/gui/battlelist/battledataviewmodel.cpp
@@ -319,7 +319,7 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 
 	if (SHOW_GAME_COLORS) {
 		// if no highlight was set, use a game-dependent shade of grey as background (windows only)
-		attr.SetBackgroundColour(battle->GetHostGameBackgroundColour());
+		attr.SetBackgroundColour(wxColour(battle->GetHostGameBackgroundColour()));
 	}
 	return true;
 }

--- a/src/gui/battlelist/battledataviewmodel.cpp
+++ b/src/gui/battlelist/battledataviewmodel.cpp
@@ -1,4 +1,6 @@
 /* This file is part of the Springlobby (GPL v2 or later), see COPYING */
+#include <string>
+
 #include "battledataviewmodel.h"
 
 #include <wx/colour.h>
@@ -6,7 +8,6 @@
 #include "ibattle.h"
 #include "useractions.h"
 #include "utils/slpaths.h"
-#include <string>
 
 BattleDataViewModel::BattleDataViewModel()
     : BaseDataViewModel<IBattle>::BaseDataViewModel(COLUMN_COUNT)
@@ -193,16 +194,21 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			sortingResult = battleA->GetHostMapName().compare(battleB->GetHostMapName());
 			break;
 
-		case GAME: {  // game prefix, players DESC, game
+		case GAME: {  // game prefix, active players DESC, total players DESC, game
 			sortingResult = battleA->GetHostGameNameWithoutVersion().compare(battleB->GetHostGameNameWithoutVersion());
-			//std::cout << "prefixA=" << prefixA << " prefixB=" << prefixB << " result=" << sortingResult;
+
+			// secondary sort by players
 			if (0 == sortingResult) {
 				int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
 				int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
 				sortingResult = playersA - playersB;
-				
-				// secondary sort by players : always DESC
-				sortingResult = !ascending ? sortingResult : (sortingResult * (-1));
+				sortingResult = !ascending ? sortingResult : (sortingResult * (-1)); // always DESC			
+			}
+			if (0 == sortingResult) {
+				int playersA = battleA->GetNumPlayers() ;
+				int playersB = battleB->GetNumPlayers() ;
+				sortingResult = playersA - playersB;
+				sortingResult = !ascending ? sortingResult : (sortingResult * (-1));  // always DESC			
 			}
 			if (0 == sortingResult) {
 				sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
@@ -223,14 +229,19 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			sortingResult = battleA->GetMaxPlayers() - battleB->GetMaxPlayers();
 			break;
 
-		case PLAYERS: { // players, game ASC
+		case PLAYERS: { // active players, total players, game ASC
 			int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
 			int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
 			sortingResult = playersA - playersB;
 			if (0 == sortingResult) {
+				int playersA = battleA->GetNumPlayers() ;
+				int playersB = battleB->GetNumPlayers() ;
+				sortingResult = playersA - playersB;
+			}
+			// secondary sort by game
+			if (0 == sortingResult) {
 				sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
-				// secondary sort by game : always ASC
-				sortingResult = ascending ? sortingResult : (sortingResult * (-1));
+				sortingResult = ascending ? sortingResult : (sortingResult * (-1));  // always ASC
 			}
 		} break;
 
@@ -260,7 +271,7 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 
 	// if battle has no players, set font color to light grey
 	if (battle->GetNumPlayers() - battle->GetSpectators() == 0) {
-		attr.SetColour(wxColour("#888899"));
+		attr.SetColour(INACTIVE_ROOM_COLOUR);
 	}
 	
 	//If founder is cause of highlight
@@ -282,7 +293,7 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 	}
 	
 	// if no highlight was set, use a game-dependent shade of grey as background (windows only)
-	attr.SetBackgroundColour(wxColour(battle->GetHostGameBackgroundColour()));
+	attr.SetBackgroundColour(battle->GetHostGameBackgroundColour());
 	return true;
 }
 

--- a/src/gui/battlelist/battledataviewmodel.cpp
+++ b/src/gui/battlelist/battledataviewmodel.cpp
@@ -254,6 +254,11 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			sortingResult = 0;
 	}
 
+	// tie-breaker based on unique battle host name
+	if (0 == sortingResult) {
+		sortingResult = battleA->GetFounder().GetNick().compare(battleB->GetFounder().GetNick());
+		sortingResult = ascending ? sortingResult : (sortingResult * (-1));  // always ASC
+	}
 	//Return direct sort order or reversed depending on ascending flag
 	return ascending ? sortingResult : (sortingResult * (-1));
 }

--- a/src/gui/battlelist/battledataviewmodel.cpp
+++ b/src/gui/battlelist/battledataviewmodel.cpp
@@ -8,10 +8,22 @@
 #include "ibattle.h"
 #include "useractions.h"
 #include "utils/slpaths.h"
+#include "utils/conversion.h"
+#include "utils/slconfig.h"
+
+SLCONFIG("/BattleListTab/InactiveRoomColor", "#888888", "Font color for battle rows with no active players");
+SLCONFIG("/BattleListTab/UseSmartSorting", "1", "Apply secondary sorting rules when sorting by game or players");
+SLCONFIG("/BattleListTab/ShowGameColors", "1", "Show game-specific color background on battle rows (windows only)");
+wxColour INACTIVE_ROOM_COLOUR = wxColour("#888888");
+bool USE_SMART_SORTING = true;
+bool SHOW_GAME_COLORS = true;
 
 BattleDataViewModel::BattleDataViewModel()
     : BaseDataViewModel<IBattle>::BaseDataViewModel(COLUMN_COUNT)
 {
+	INACTIVE_ROOM_COLOUR = wxColour(STD_STRING(cfg().ReadString(_T("/BattleListTab/InactiveRoomColor"))));
+	USE_SMART_SORTING = STD_STRING(cfg().ReadString(_T("/BattleListTab/UseSmartSorting"))).compare("1") == 0;
+	SHOW_GAME_COLORS = STD_STRING(cfg().ReadString(_T("/BattleListTab/ShowGameColors"))).compare("1") == 0;
 }
 
 BattleDataViewModel::~BattleDataViewModel()
@@ -194,23 +206,27 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			sortingResult = battleA->GetHostMapName().compare(battleB->GetHostMapName());
 			break;
 
-		case GAME: {  // game prefix, active players DESC, total players DESC, game
-			sortingResult = battleA->GetHostGameNameWithoutVersion().compare(battleB->GetHostGameNameWithoutVersion());
+		case GAME: { 
+			if (USE_SMART_SORTING) {  // game prefix, active players DESC, total players DESC, game
+				sortingResult = battleA->GetHostGameNameWithoutVersion().compare(battleB->GetHostGameNameWithoutVersion());
 
-			// secondary sort by players
-			if (0 == sortingResult) {
-				int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
-				int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
-				sortingResult = playersA - playersB;
-				sortingResult = !ascending ? sortingResult : (sortingResult * (-1)); // always DESC			
-			}
-			if (0 == sortingResult) {
-				int playersA = battleA->GetNumPlayers() ;
-				int playersB = battleB->GetNumPlayers() ;
-				sortingResult = playersA - playersB;
-				sortingResult = !ascending ? sortingResult : (sortingResult * (-1));  // always DESC			
-			}
-			if (0 == sortingResult) {
+				// secondary sort by players
+				if (0 == sortingResult) {
+					int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
+					int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
+					sortingResult = playersA - playersB;
+					sortingResult = !ascending ? sortingResult : (sortingResult * (-1)); // always DESC			
+				}
+				if (0 == sortingResult) {
+					int playersA = battleA->GetNumPlayers() ;
+					int playersB = battleB->GetNumPlayers() ;
+					sortingResult = playersA - playersB;
+					sortingResult = !ascending ? sortingResult : (sortingResult * (-1));  // always DESC			
+				}
+				if (0 == sortingResult) {
+					sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
+				}
+			} else {
 				sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
 			}
 		} break;
@@ -233,15 +249,19 @@ int BattleDataViewModel::Compare(const wxDataViewItem& itemA,
 			int playersA = battleA->GetNumPlayers() - battleA->GetSpectators();
 			int playersB = battleB->GetNumPlayers() - battleB->GetSpectators();
 			sortingResult = playersA - playersB;
-			if (0 == sortingResult) {
-				int playersA = battleA->GetNumPlayers() ;
-				int playersB = battleB->GetNumPlayers() ;
-				sortingResult = playersA - playersB;
-			}
-			// secondary sort by game
-			if (0 == sortingResult) {
-				sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
-				sortingResult = ascending ? sortingResult : (sortingResult * (-1));  // always ASC
+			
+			if (USE_SMART_SORTING) {			
+				if (0 == sortingResult) {
+					int playersA = battleA->GetNumPlayers() ;
+					int playersB = battleB->GetNumPlayers() ;
+					sortingResult = playersA - playersB;
+				}
+
+				// secondary sort by game
+				if (0 == sortingResult) {
+					sortingResult = battleA->GetHostGameName().compare(battleB->GetHostGameName());
+					sortingResult = ascending ? sortingResult : (sortingResult * (-1));  // always ASC
+				}
 			}
 		} break;
 
@@ -297,8 +317,10 @@ bool BattleDataViewModel::GetAttr(const wxDataViewItem& item,
 		}
 	}
 	
-	// if no highlight was set, use a game-dependent shade of grey as background (windows only)
-	attr.SetBackgroundColour(battle->GetHostGameBackgroundColour());
+	if (SHOW_GAME_COLORS) {
+		// if no highlight was set, use a game-dependent shade of grey as background (windows only)
+		attr.SetBackgroundColour(battle->GetHostGameBackgroundColour());
+	}
 	return true;
 }
 

--- a/src/gui/battlelist/battledataviewmodel.h
+++ b/src/gui/battlelist/battledataviewmodel.h
@@ -18,7 +18,6 @@ public:
 	virtual wxString GetColumnType(unsigned int column) const override;
 
 private:
-	wxColour INACTIVE_ROOM_COLOUR = wxColour("#888888");
 	enum ColumnIndexes {
 		STATUS = 0,
 		COUNTRY,

--- a/src/gui/battlelist/battledataviewmodel.h
+++ b/src/gui/battlelist/battledataviewmodel.h
@@ -18,6 +18,7 @@ public:
 	virtual wxString GetColumnType(unsigned int column) const override;
 
 private:
+	wxColour INACTIVE_ROOM_COLOUR = wxColour("#888888");
 	enum ColumnIndexes {
 		STATUS = 0,
 		COUNTRY,

--- a/src/ibattle.cpp
+++ b/src/ibattle.cpp
@@ -761,12 +761,7 @@ void IBattle::SetHostGame(const std::string& gamename, const std::string& hash)
 	for (char& c : gameNameWithoutVersion) {
 		sum += c;
 	}
-	int sumR = 255 - ((sum % 7)*10);
-	int sumG = 255 - ((sum % 7)*10);
-	int sumB = 255 - ((sum % 4)*10);
-	char buff[11];
-	sprintf(buff, "#%2x%2x%2x",sumR,sumG,sumB);
-	gameBackgroundColour = wxColour(buff);
+	gameBackgroundColour = wxColour(GAME_BL_COLOURS[sum % 11]);
 }
 
 

--- a/src/ibattle.cpp
+++ b/src/ibattle.cpp
@@ -754,6 +754,16 @@ void IBattle::SetHostGame(const std::string& gamename, const std::string& hash)
 	m_game_loaded = gamename.empty();
 	m_host_game.name = gamename;
 	m_host_game.hash = hash;
+	
+	gameNameWithoutVersion = gamename.substr(0,gamename.find_last_of(" "));
+	int sum = 0;
+	for (char& c : gameNameWithoutVersion) {
+		sum += c;
+	}
+	sum = 255 - (sum % 60);
+	char buff[11];
+	sprintf(buff, "#%2x%2x%2x",sum,sum,sum);
+	gameBackgroundColour = buff;
 }
 
 
@@ -798,6 +808,16 @@ const std::string& IBattle::GetHostGameName() const
 	return m_host_game.name;
 }
 
+
+const std::string& IBattle::GetHostGameNameWithoutVersion() const
+{
+	return gameNameWithoutVersion;
+}
+
+const std::string& IBattle::GetHostGameBackgroundColour() const
+{
+	return gameBackgroundColour;
+}
 
 const std::string& IBattle::GetHostGameHash() const
 {

--- a/src/ibattle.cpp
+++ b/src/ibattle.cpp
@@ -333,7 +333,7 @@ bool IBattle::ShouldAutoStart() const
 	if (GetInGame())
 		return false;
 	if (!IsLocked() && (GetNumActivePlayers() < m_opts.maxplayers))
-		return false; // proceed checking for ready & symc players only if the battle is full or locked
+		return false; // proceed checking for ready & sync players only if the battle is full or locked
 	if (!IsEveryoneReady())
 		return false;
 	return true;
@@ -756,14 +756,17 @@ void IBattle::SetHostGame(const std::string& gamename, const std::string& hash)
 	m_host_game.hash = hash;
 	
 	gameNameWithoutVersion = gamename.substr(0,gamename.find_last_of(" "));
+	// generate game-specific colour
 	int sum = 0;
 	for (char& c : gameNameWithoutVersion) {
 		sum += c;
 	}
-	sum = 255 - (sum % 60);
+	int sumR = 255 - ((sum % 7)*10);
+	int sumG = 255 - ((sum % 7)*10);
+	int sumB = 255 - ((sum % 4)*10);
 	char buff[11];
-	sprintf(buff, "#%2x%2x%2x",sum,sum,sum);
-	gameBackgroundColour = buff;
+	sprintf(buff, "#%2x%2x%2x",sumR,sumG,sumB);
+	gameBackgroundColour = wxColour(buff);
 }
 
 
@@ -814,7 +817,7 @@ const std::string& IBattle::GetHostGameNameWithoutVersion() const
 	return gameNameWithoutVersion;
 }
 
-const std::string& IBattle::GetHostGameBackgroundColour() const
+const wxColour& IBattle::GetHostGameBackgroundColour() const
 {
 	return gameBackgroundColour;
 }

--- a/src/ibattle.cpp
+++ b/src/ibattle.cpp
@@ -761,7 +761,7 @@ void IBattle::SetHostGame(const std::string& gamename, const std::string& hash)
 	for (char& c : gameNameWithoutVersion) {
 		sum += c;
 	}
-	gameBackgroundColour = wxColour(GAME_BL_COLOURS[sum % 11]);
+	gameBackgroundColour = GAME_BL_COLOURS[sum % 11];
 }
 
 
@@ -812,7 +812,7 @@ const std::string& IBattle::GetHostGameNameWithoutVersion() const
 	return gameNameWithoutVersion;
 }
 
-const wxColour& IBattle::GetHostGameBackgroundColour() const
+const std::string& IBattle::GetHostGameBackgroundColour() const
 {
 	return gameBackgroundColour;
 }

--- a/src/ibattle.h
+++ b/src/ibattle.h
@@ -27,16 +27,16 @@ const unsigned int DEFAULT_EXTERNAL_UDP_SOURCE_PORT = 16941;
 
 const std::string GAME_BL_COLOURS[11] = {
 	"#ffffff",
-	"#ffffcc",
-	"#ccffcc",
-	"#ccccff",
-	"#ffcccc",
-	"#dddddd",
-	"#ddffff",
-	"#ccddcc",
-	"#ffeecc",
+	"#ffffdd",
+	"#ddffdd",
+	"#fff2ee",
+	"#ffdddd",
 	"#eeeeee",
-	"#ddeeff"
+	"#eeffff",
+	"#ddeedd",
+	"#fff2dd",
+	"#f3f3f3",
+	"#eef2ff"
 };
 
 

--- a/src/ibattle.h
+++ b/src/ibattle.h
@@ -25,6 +25,21 @@ lsl/battle/ibattle.h
 const unsigned int DEFAULT_SERVER_PORT = 8452;
 const unsigned int DEFAULT_EXTERNAL_UDP_SOURCE_PORT = 16941;
 
+const std::string GAME_BL_COLOURS[11] = {
+	"#ffffff",
+	"#ffffcc",
+	"#ccffcc",
+	"#ccccff",
+	"#ffcccc",
+	"#dddddd",
+	"#ddffff",
+	"#ccddcc",
+	"#ffeecc",
+	"#eeeeee",
+	"#ddeeff"
+};
+
+
 class IBattle;
 class IServer;
 class AutoHost;

--- a/src/ibattle.h
+++ b/src/ibattle.h
@@ -20,6 +20,7 @@ lsl/battle/ibattle.h
 #include "user.h"
 #include "userlist.h"
 #include <lslunitsync/optionswrapper.h>
+#include <wx/colour.h>
 
 const unsigned int DEFAULT_SERVER_PORT = 8452;
 const unsigned int DEFAULT_EXTERNAL_UDP_SOURCE_PORT = 16941;
@@ -229,7 +230,7 @@ public:
 	virtual const LSL::UnitsyncGame& LoadGame();
 	virtual const std::string& GetHostGameName() const;
 	virtual const std::string& GetHostGameNameWithoutVersion() const;
-	virtual const std::string& GetHostGameBackgroundColour() const;
+	virtual const wxColour& GetHostGameBackgroundColour() const;
 	virtual const std::string& GetHostGameHash() const;
 
 	virtual bool MapExists(bool comparehash = true) const;
@@ -722,7 +723,7 @@ private:
 	LSL::UnitsyncGame m_host_game;
 	LSL::UnitsyncGame m_local_game;
 	std::string gameNameWithoutVersion;
-	std::string gameBackgroundColour;
+	wxColour gameBackgroundColour;
 
 	std::map<std::string, int> m_restricted_units;
 	std::string m_previous_local_game_name;

--- a/src/ibattle.h
+++ b/src/ibattle.h
@@ -20,7 +20,6 @@ lsl/battle/ibattle.h
 #include "user.h"
 #include "userlist.h"
 #include <lslunitsync/optionswrapper.h>
-#include <wx/colour.h>
 
 const unsigned int DEFAULT_SERVER_PORT = 8452;
 const unsigned int DEFAULT_EXTERNAL_UDP_SOURCE_PORT = 16941;
@@ -245,7 +244,7 @@ public:
 	virtual const LSL::UnitsyncGame& LoadGame();
 	virtual const std::string& GetHostGameName() const;
 	virtual const std::string& GetHostGameNameWithoutVersion() const;
-	virtual const wxColour& GetHostGameBackgroundColour() const;
+	virtual const std::string& GetHostGameBackgroundColour() const;
 	virtual const std::string& GetHostGameHash() const;
 
 	virtual bool MapExists(bool comparehash = true) const;
@@ -738,7 +737,7 @@ private:
 	LSL::UnitsyncGame m_host_game;
 	LSL::UnitsyncGame m_local_game;
 	std::string gameNameWithoutVersion;
-	wxColour gameBackgroundColour;
+	std::string gameBackgroundColour;
 
 	std::map<std::string, int> m_restricted_units;
 	std::string m_previous_local_game_name;

--- a/src/ibattle.h
+++ b/src/ibattle.h
@@ -228,6 +228,8 @@ public:
 	virtual void SetLocalGame(const LSL::UnitsyncGame& game);
 	virtual const LSL::UnitsyncGame& LoadGame();
 	virtual const std::string& GetHostGameName() const;
+	virtual const std::string& GetHostGameNameWithoutVersion() const;
+	virtual const std::string& GetHostGameBackgroundColour() const;
 	virtual const std::string& GetHostGameHash() const;
 
 	virtual bool MapExists(bool comparehash = true) const;
@@ -719,6 +721,8 @@ private:
 	LSL::UnitsyncMap m_host_map;
 	LSL::UnitsyncGame m_host_game;
 	LSL::UnitsyncGame m_local_game;
+	std::string gameNameWithoutVersion;
+	std::string gameBackgroundColour;
 
 	std::map<std::string, int> m_restricted_units;
 	std::string m_previous_local_game_name;


### PR DESCRIPTION
- when sorting by "game", sort by : game prefix (without version), players DESC, game
(this will highlight the most populated rooms for each game)

- when sorting by "players", sort by :  players, game ASC
(this will show the most populated rooms first, but then show the remaining rooms sorted by game)

- show grey text on room rows without players to make the ones that do have players stand out (default text color is black)

- on windows (as setBackgroundColour doesn't do anything on SL on ubuntu), change the default row background from white to a shade of light grey that depends on the game prefix, to differentiate between sets of rows for different games
