### PR TITLE
fix start button logic

### DIFF
--- a/src/gui/hosting/battleroomtab.cpp
+++ b/src/gui/hosting/battleroomtab.cpp
@@ -637,51 +637,43 @@ void BattleRoomTab::OnPromote(wxCommandEvent& /*unused*/)
  *    1       1      0     DL -> ready -> start
  *    1       1      1     DL -> ready -> start
  */
+
 void BattleRoomTab::OnStart(wxCommandEvent& /*unused*/)
 {
 	slLogDebugFunc("");
 	if (m_battle == nullptr)
 		return;
 
-	if (ui().IsSpringRunning()) {
-		customMessageBoxModal(SL_MAIN_ICON, _("You are already playing/spectating."), _("Error"));
-		return;
-	}
-
 	if (ui().NeedsDownload(m_battle)) {
-		customMessageBoxModal(SL_MAIN_ICON, _("You must download missing content before you"
-		  " can start or wait for the downloads to finish if they had been started already."),
+		customMessageBoxModal(SL_MAIN_ICON, _("You must download missing content before you can start. You might need to wait for any existing downloads to finish!"),
 		  _("Error"));
 		return;
 	}
 
-	//start manually clicked, force start
+	//start manually clicked
 	m_battle->SetAutolaunchGame(true);
-	m_ready_chk->SetValue(true);
-	OnImReady();
 
-	// Is remote battle running?
-	if (m_battle->GetFounder().Status().in_game) {
-		m_battle->StartSpring();
-	} else { // No, it is not running.
-		if (m_battle->GetMe().BattleStatus().spectator) {
-			customMessageBoxModal(SL_MAIN_ICON,
-			  _("No battle is running. You must be a player to start"), _("Error"));
-		} else { // I am a player
-			if (m_battle->IsEveryoneReady()) {
-				if (m_battle->IsFounderMe()) {
-					m_battle->SaveMapDefaults(); // save map presets
-					m_battle->StartHostedBattle();
-				} else {
-					m_battle->m_autohost_manager->GetAutohostHandler().Start();
-				}
-			} else {
-				int answer = customMessageBox(SL_MAIN_ICON,
-				  _("Some players are not ready, ring them?"),
-				  _("Not ready"), wxYES | wxCANCEL);
-				if (answer == wxYES)
-					m_battle->RingNotSyncedAndNotReadyPlayers();
+	if (m_battle->IsFounderMe()) {
+		m_battle->GetMe().BattleStatus().ready = true;
+		if (!m_battle->IsEveryoneReady()) {
+			int answer = customMessageBox(SL_MAIN_ICON, _("Some players are not ready yet.\nDo you want to force start?\nClick no to ring all unready players."), _("Not ready"), wxYES_NO | wxCANCEL);
+			if (answer == wxNO) {
+				m_battle->RingNotSyncedAndNotReadyPlayers();
+				return;
 			}
+		}
+		m_battle->SaveMapDefaults(); // save map presets
+		m_battle->StartHostedBattle();
+
+	} else {
+		if (m_battle->GetFounder().Status().in_game) {
+			if (!ui().IsSpringRunning())
+				m_battle->StartSpring();
+			else
+				customMessageBoxModal(SL_MAIN_ICON, _("Spring is already running."), _("Error"));
+		} else {
+			m_battle->m_autohost_manager->GetAutohostHandler().Start();
+			//customMessageBoxNoModal( SL_MAIN_ICON, _("Host is not ingame."), _("Error") );
 		}
 	}
 


### PR DESCRIPTION
After https://github.com/springlobby/springlobby/commit/ef7405654f0f2497669b4c562b34acbdb1754d2f it is not possible for a SL user to host a multiplayer game unless they are a player (i.e. not a spectator). This broke human hosting of online games, as well as making developing AIs difficult in cases where autohosts cannot/should not be used for testing them.

This pr reverts part of https://github.com/springlobby/springlobby/commit/ef7405654f0f2497669b4c562b34acbdb1754d2f, but keeps the warning concerning missing content.