### PR TITLE
Explicitly include std::string - small build fix

### DIFF
--- a/src/battlelist.h
+++ b/src/battlelist.h
@@ -16,6 +16,7 @@ lsl/container/battlelist.h
 
 
 #include <map>
+#include <string>
 #include "utils/mixins.h"
 
 class IBattle;

--- a/src/utils/sortutil.h
+++ b/src/utils/sortutil.h
@@ -4,6 +4,7 @@
 #define SPRINGLOBBY_SORTUTIL_H_INCLUDED
 
 #include <map>
+#include <string>
 //! set direction to +1 for down, -1 for up
 struct SortOrderItem {
 	int col;


### PR DESCRIPTION
Fixes issue where std::string is not implicitly included on GCC 10.1.0. 
https://github.com/springlobby/springlobby/issues/951#issuecomment-637669803

Build log with error before fix:
[build_log.txt](https://github.com/springlobby/springlobby/files/4718618/build_log.txt)